### PR TITLE
influxdb: skip DataFrameClient with INFLUXDB_NO_DATAFRAME_CLIENT

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,9 @@ Examples
 
 Here's a basic example (for more see the examples directory)::
 
-    $ python
+    # Since the DataFrame client is slow to import, if you only need InfluxDBClient,
+    # use INFLUXDB_NO_DATAFRAME_CLIENT.
+    $ INFLUXDB_NO_DATAFRAME_CLIENT=1 python
 
     >>> from influxdb import InfluxDBClient
 

--- a/docs/source/api-documentation.rst
+++ b/docs/source/api-documentation.rst
@@ -10,6 +10,9 @@ To connect to a InfluxDB, you must create a
 connects to InfluxDB on ``localhost`` with the default
 ports. The below instantiation statements are all equivalent::
 
+    # Set INFLUXDB_NO_DATAFRAME_CLIENT to save import time for InfluxDBClient
+    import os
+    os.environ[ "INFLUXDB_NO_DATAFRAME_CLIENT" ] = "1"
     from influxdb import InfluxDBClient
 
     # using Http

--- a/examples/tutorial.py
+++ b/examples/tutorial.py
@@ -3,6 +3,8 @@
 
 import argparse
 
+import os
+os.environ[ "INFLUXDB_NO_DATAFRAME_CLIENT" ] = "1"
 from influxdb import InfluxDBClient
 
 

--- a/influxdb/__init__.py
+++ b/influxdb/__init__.py
@@ -7,15 +7,20 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from .client import InfluxDBClient
-from .dataframe_client import DataFrameClient
 from .helper import SeriesHelper
+
+import os
+
+_DATAFRAME_CLIENT = "INFLUXDB_NO_DATAFRAME_CLIENT" not in os.environ
+if _DATAFRAME_CLIENT:
+   from .dataframe_client import DataFrameClient
 
 
 __all__ = [
     'InfluxDBClient',
-    'DataFrameClient',
     'SeriesHelper',
 ]
-
+if _DATAFRAME_CLIENT:
+   __all__.append( 'DataFrameClient' )
 
 __version__ = '5.0.0'


### PR DESCRIPTION
Since the DataFrameClient import is very expensive (imports pandas,
which brings in a lot of modules), provide an env var
"INFLUXDB_NO_DATAFRAME_CLIENT" that can be used to skip loading it when
just the simple InfluxDBClient is needed.