### PR TITLE
Allow skipping DataFrameClient import

### DIFF
--- a/docs/source/api-documentation.rst
+++ b/docs/source/api-documentation.rst
@@ -10,6 +10,10 @@ To connect to a InfluxDB, you must create a
 connects to InfluxDB on ``localhost`` with the default
 ports. The below instantiation statements are all equivalent::
 
+    # Set INFLUXDB_NO_DATAFRAME_CLIENT to skip the expensive DataFrameClient
+    # import in cases where you only need the basic InfluxDBClient.
+    os.environ["INFLUXDB_NO_DATAFRAME_CLIENT"] = "1"
+
     from influxdb import InfluxDBClient
 
     # using Http

--- a/examples/tutorial.py
+++ b/examples/tutorial.py
@@ -3,6 +3,8 @@
 
 import argparse
 
+import os
+os.environ["INFLUXDB_NO_DATAFRAME_CLIENT"] = "1"
 from influxdb import InfluxDBClient
 
 

--- a/influxdb/__init__.py
+++ b/influxdb/__init__.py
@@ -17,7 +17,7 @@ __all__ = [
     'SeriesHelper',
 ]
 
-if os.environ.get("INFLUXDB_NO_DATAFRAME_CLIENT", "0").lower() not in ("0", "false"):
+if os.environ.get("INFLUXDB_NO_DATAFRAME_CLIENT", "0").lower() not in ("1", "true"):
    from .dataframe_client import DataFrameClient
    __all__.append( "DataFrameClient" )
 

--- a/influxdb/__init__.py
+++ b/influxdb/__init__.py
@@ -19,7 +19,7 @@ __all__ = [
 
 NO_DATAFRAME_CLIENT = os.environ.get("INFLUXDB_NO_DATAFRAME_CLIENT", "0")
 if NO_DATAFRAME_CLIENT.lower() not in ("1", "true"):
-    from .dataframe_client import DataFrameClient # noqa: F401 unused import
+    from .dataframe_client import DataFrameClient  # noqa: F401 unused import
     __all__.append("DataFrameClient")
 
 

--- a/influxdb/__init__.py
+++ b/influxdb/__init__.py
@@ -17,7 +17,7 @@ __all__ = [
     'SeriesHelper',
 ]
 
-if "INFLUXDB_NO_DATAFRAME_CLIENT" not in os.environ:
+if os.environ.get("INFLUXDB_NO_DATAFRAME_CLIENT", "0").lower() not in ("0", "false"):
    from .dataframe_client import DataFrameClient
    __all__.append( "DataFrameClient" )
 

--- a/influxdb/__init__.py
+++ b/influxdb/__init__.py
@@ -20,7 +20,7 @@ __all__ = [
 NO_DATAFRAME_CLIENT = os.environ.get("INFLUXDB_NO_DATAFRAME_CLIENT", "0")
 if NO_DATAFRAME_CLIENT.lower() not in ("1", "true"):
     from .dataframe_client import DataFrameClient # noqa: F401 unused import
-     __all__.append("DataFrameClient")
+    __all__.append("DataFrameClient")
 
 
 __version__ = '5.0.0'

--- a/influxdb/__init__.py
+++ b/influxdb/__init__.py
@@ -17,9 +17,10 @@ __all__ = [
     'SeriesHelper',
 ]
 
-if os.environ.get("INFLUXDB_NO_DATAFRAME_CLIENT", "0").lower() not in ("1", "true"):
-   from .dataframe_client import DataFrameClient
-   __all__.append( "DataFrameClient" )
+NO_DATAFRAME_CLIENT = os.environ.get("INFLUXDB_NO_DATAFRAME_CLIENT", "0")
+if NO_DATAFRAME_CLIENT.lower() not in ("1", "true"):
+    from .dataframe_client import DataFrameClient # noqa: F401 unused import
+     __all__.append("DataFrameClient")
 
 
 __version__ = '5.0.0'

--- a/influxdb/__init__.py
+++ b/influxdb/__init__.py
@@ -6,16 +6,20 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import os
+
 from .client import InfluxDBClient
-from .dataframe_client import DataFrameClient
 from .helper import SeriesHelper
 
 
 __all__ = [
     'InfluxDBClient',
-    'DataFrameClient',
     'SeriesHelper',
 ]
+
+if "INFLUXDB_NO_DATAFRAME_CLIENT" not in os.environ:
+   from .dataframe_client import DataFrameClient
+   __all__.append( "DataFrameClient" )
 
 
 __version__ = '5.0.0'


### PR DESCRIPTION
Importing the DataFrameClient can take quite a while,
especially when the source files aren't yet loaded into
the page cache.

This patch adds an environment variable, INFLUXDB_NO_DATAFRAME_CLIENT,
to allow users of this package to skip this import in cases where
they don't need it.

This pull request is a cherry pick of all the commits from
https://github.com/influxdata/influxdb-python/pull/850